### PR TITLE
Remove redundant .source.ino definition which is causing an error

### DIFF
--- a/snippets/language-ino.cson
+++ b/snippets/language-ino.cson
@@ -2,7 +2,6 @@
   '#ifndef … #define … #endif':
     'prefix': 'def'
     'body': '#ifndef ${1:SYMBOL}\n#define ${2:SYMBOL} ${3:value}\n#endif'
-'.source.ino, .source.ino\\+\\+':
   '#include <>':
     'prefix': 'Inc'
     'body': '#include <${1:.h}>'


### PR DESCRIPTION
At startup, Atom was throwing the following error:
```
Failed to load snippets from '/Users/technoligarch/.atom/packages/language-ino/snippets/language-ino.cson'

/Users/technoligarch/.atom/packages/language-ino/snippets/language-ino.cson: Duplicate key '.source.ino, .source.ino\+\+'
```

After removing the duplicate `'.source.ino, .source.ino\\+\\+'` statement, it got fixed.